### PR TITLE
:sparkles: Add Curry function for 1 arity (#24)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 cache:
   directories:

--- a/forge/src/main/kotlin/com/github/kittinunf/forge/util/Currying.kt
+++ b/forge/src/main/kotlin/com/github/kittinunf/forge/util/Currying.kt
@@ -1,5 +1,12 @@
 package com.github.kittinunf.forge.util
 
+fun <A, X> Function1<A, X>.curry(): (A) -> X {
+    return { a -> invoke(a) }
+}
+
+val <A, X> Function1<A, X>.create: (A) -> (X)
+    get() = curry()
+
 fun <A, B, X> Function2<A, B, X>.curry(): (A) -> (B) -> X {
     return { a ->
         { b -> invoke(a, b) }

--- a/forge/src/test/kotlin/com/github/kittinunf/forge/CurryingTest.kt
+++ b/forge/src/test/kotlin/com/github/kittinunf/forge/CurryingTest.kt
@@ -63,6 +63,13 @@ class CurryingTest : BaseTest() {
     }
 
     @Test
+    fun testCurrying1() {
+        val negate = { x: Int -> x * (-1) }
+        val curry = negate.create
+        assertThat(curry(1), equalTo(-1))
+    }
+
+    @Test
     fun testCurrying2() {
         val multiply = { x: Int, y: Int -> x * y }
         val curry = multiply.create


### PR DESCRIPTION
Provides currying function for single data field classes enabling clients to use the familiar syntax to create `Deserializable`'s also from these single data fields:

```kotlin
data class Pet(val name: String)

val deserializer: (JSON) -> DeserializedResult<Pet> = { json: JSON ->
  ::Pet.create.map(json at "name")
}
```

Relates to #24.

closes #24 